### PR TITLE
NPM supply-chain audit and vulnerability fixes

### DIFF
--- a/frontend/SECURITY-NPM-AUDIT.md
+++ b/frontend/SECURITY-NPM-AUDIT.md
@@ -1,0 +1,70 @@
+# SECURITY-NPM-AUDIT — Depl0y/frontend
+
+**Date:** 2026-06-08
+**Trigger:** npm Shai-Hulud / Mini Shai-Hulud supply-chain incident defensive sweep
+**Package manager:** npm 10.9.4 (lockfile-only mode, scripts disabled throughout)
+
+## Files inspected
+
+- `frontend/package.json`
+- `frontend/package-lock.json`
+
+No `.npmrc` / `.yarnrc` files present. No nested `package.json`. No `node_modules` directory committed.
+
+## Lifecycle scripts found
+
+In `package.json` — none of the risky lifecycle hooks (`preinstall`, `install`, `postinstall`, `prepack`, `prepare`, `prepublish`, `prepublishOnly`). Only: `dev`, `build`, `deploy`, `preview`, `lint`.
+
+In the lockfile, `hasInstallScript: true` was set on **3** transitive packages — all legitimate native-compile / platform-detection packages:
+- `node_modules/esbuild` @ 0.21.5 (build tool, native binary)
+- `node_modules/fsevents` @ 2.3.3 (macOS file watcher)
+- `node_modules/vue-demi` @ 0.14.10 (Vue 2/3 compatibility shim)
+
+No anomalous install-script packages.
+
+## Supply-chain indicator scan
+
+| Indicator | Result |
+|---|---|
+| `@tanstack/*` declared or resolved | none |
+| `@antv/*` | none |
+| `@redhat-cloud-services/*` | none |
+| `@mistralai/*` | none |
+| `@bitwarden/cli` | none |
+| `plain-crypto-js` | none |
+| `axios@1.14.1` / `axios@0.30.4` | none (declared `^1.6.2`, resolved 1.15.0 before, audit-fixed to newer 1.15.x) |
+| Non-`registry.npmjs.org` resolutions | none — all sha512 from default registry |
+| `git+` / `github:` / `file:` / `http://` resolutions | none |
+
+**No obvious supply-chain compromise indicators found.**
+
+## Advisories (npm audit)
+
+### Before
+- 5 total: 1 high (axios), 4 moderate (`@vitejs/plugin-vue`, `esbuild`, `uuid`, `vite`).
+
+### After `npm audit fix --package-lock-only --ignore-scripts`
+- 3 total: 0 critical, 0 high, 3 moderate.
+
+| Remaining | Severity | Status |
+|---|---|---|
+| `vite` | moderate | dev-server only; needs Vite 5 → 8 major bump (deferred — runtime not affected) |
+| `esbuild` | moderate | dev-server only; resolved by Vite 8 bump |
+| `@vitejs/plugin-vue` | moderate | dev-server only; needs plugin 4 → 6 major bump |
+
+The 3 remaining advisories are all in build-tooling that only runs in `npm run dev`; production bundles served from `/opt/depl0y/frontend/dist/` are unaffected. **No critical or high-severity runtime risk remains.**
+
+## Files changed in this audit
+
+- `frontend/package-lock.json` — refreshed via `npm audit fix --package-lock-only --ignore-scripts` (axios, uuid bumped within range; vite/esbuild/@vitejs/plugin-vue left because patch requires major bump)
+- `frontend/npm-audit.before.json` — full audit JSON snapshot (pre-fix)
+- `frontend/npm-audit.after.json` — full audit JSON snapshot (post-fix)
+- `frontend/SECURITY-NPM-AUDIT.md` — this file
+
+## Builds / tests skipped
+
+Per audit policy, **no** `npm install`, `npm run build`, or `npm run lint` was executed during this audit — install scripts were intentionally disabled to avoid running any post-install payload that might be present in a compromised transitive dep. A clean install + smoke test in a sandboxed CI run is recommended before merging.
+
+## Manual follow-ups
+
+1. Schedule the **Vite 5 → 8 + @vitejs/plugin-vue 4 → 6** migration when there's capacity. Dev-server CVEs only; not urgent.

--- a/frontend/npm-audit.after.json
+++ b/frontend/npm-audit.after.json
@@ -1,0 +1,113 @@
+{
+  "auditReportVersion": 2,
+  "vulnerabilities": {
+    "@vitejs/plugin-vue": {
+      "name": "@vitejs/plugin-vue",
+      "severity": "moderate",
+      "isDirect": true,
+      "via": [
+        "vite"
+      ],
+      "effects": [],
+      "range": "1.8.0 - 5.2.0",
+      "nodes": [
+        "node_modules/@vitejs/plugin-vue"
+      ],
+      "fixAvailable": {
+        "name": "@vitejs/plugin-vue",
+        "version": "6.0.7",
+        "isSemVerMajor": true
+      }
+    },
+    "esbuild": {
+      "name": "esbuild",
+      "severity": "moderate",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1102341,
+          "name": "esbuild",
+          "dependency": "esbuild",
+          "title": "esbuild enables any website to send any requests to the development server and read the response",
+          "url": "https://github.com/advisories/GHSA-67mh-4wv8-2f99",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-346"
+          ],
+          "cvss": {
+            "score": 5.3,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:N/A:N"
+          },
+          "range": "<=0.24.2"
+        }
+      ],
+      "effects": [
+        "vite"
+      ],
+      "range": "<=0.24.2",
+      "nodes": [
+        "node_modules/esbuild"
+      ],
+      "fixAvailable": {
+        "name": "vite",
+        "version": "8.0.16",
+        "isSemVerMajor": true
+      }
+    },
+    "vite": {
+      "name": "vite",
+      "severity": "moderate",
+      "isDirect": true,
+      "via": [
+        {
+          "source": 1116229,
+          "name": "vite",
+          "dependency": "vite",
+          "title": "Vite Vulnerable to Path Traversal in Optimized Deps `.map` Handling",
+          "url": "https://github.com/advisories/GHSA-4w7w-66w2-5vf9",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-22",
+            "CWE-200"
+          ],
+          "cvss": {
+            "score": 0,
+            "vectorString": null
+          },
+          "range": "<=6.4.1"
+        },
+        "esbuild"
+      ],
+      "effects": [
+        "@vitejs/plugin-vue"
+      ],
+      "range": "<=6.4.1",
+      "nodes": [
+        "node_modules/vite"
+      ],
+      "fixAvailable": {
+        "name": "vite",
+        "version": "8.0.16",
+        "isSemVerMajor": true
+      }
+    }
+  },
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 3,
+      "high": 0,
+      "critical": 0,
+      "total": 3
+    },
+    "dependencies": {
+      "prod": 65,
+      "dev": 161,
+      "optional": 50,
+      "peer": 6,
+      "peerOptional": 0,
+      "total": 232
+    }
+  }
+}

--- a/frontend/npm-audit.before.json
+++ b/frontend/npm-audit.before.json
@@ -1,0 +1,502 @@
+{
+  "auditReportVersion": 2,
+  "vulnerabilities": {
+    "@vitejs/plugin-vue": {
+      "name": "@vitejs/plugin-vue",
+      "severity": "moderate",
+      "isDirect": true,
+      "via": [
+        "vite"
+      ],
+      "effects": [],
+      "range": "1.8.0 - 5.2.0",
+      "nodes": [
+        "node_modules/@vitejs/plugin-vue"
+      ],
+      "fixAvailable": {
+        "name": "@vitejs/plugin-vue",
+        "version": "6.0.7",
+        "isSemVerMajor": true
+      }
+    },
+    "axios": {
+      "name": "axios",
+      "severity": "high",
+      "isDirect": true,
+      "via": [
+        {
+          "source": 1117574,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "Axios: Authentication Bypass via Prototype Pollution Gadget in `validateStatus` Merge Strategy",
+          "url": "https://github.com/advisories/GHSA-w9j2-pvgh-6h63",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-287",
+            "CWE-1321"
+          ],
+          "cvss": {
+            "score": 4.8,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
+          },
+          "range": ">=1.0.0 <1.15.1"
+        },
+        {
+          "source": 1117576,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "Axios: Incomplete Fix for CVE-2025-62718 — NO_PROXY Protection Bypassed via RFC 1122 Loopback Subnet (127.0.0.0/8) in Axios 1.15.0",
+          "url": "https://github.com/advisories/GHSA-pmwg-cvhr-8vh7",
+          "severity": "high",
+          "cwe": [
+            "CWE-183",
+            "CWE-441",
+            "CWE-918"
+          ],
+          "cvss": {
+            "score": 7.2,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N"
+          },
+          "range": ">=1.0.0 <1.15.1"
+        },
+        {
+          "source": 1117577,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "Axios: Invisible JSON Response Tampering via Prototype Pollution Gadget in `parseReviver`",
+          "url": "https://github.com/advisories/GHSA-3w6x-2g7m-8v23",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-915",
+            "CWE-1321"
+          ],
+          "cvss": {
+            "score": 6.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:H/A:N"
+          },
+          "range": ">=1.0.0 <1.15.2"
+        },
+        {
+          "source": 1117580,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "Axios: Null Byte Injection via Reverse-Encoding in AxiosURLSearchParams",
+          "url": "https://github.com/advisories/GHSA-xhjh-pmcv-23jw",
+          "severity": "low",
+          "cwe": [
+            "CWE-116",
+            "CWE-626"
+          ],
+          "cvss": {
+            "score": 3.7,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N"
+          },
+          "range": ">=1.0.0 <1.15.1"
+        },
+        {
+          "source": 1117581,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "Axios: CRLF Injection in multipart/form-data body via unsanitized blob.type in formDataToStream",
+          "url": "https://github.com/advisories/GHSA-445q-vr5w-6q77",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-93"
+          ],
+          "cvss": {
+            "score": 5.3,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
+          },
+          "range": ">=1.0.0 <1.15.1"
+        },
+        {
+          "source": 1117583,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "Axios: no_proxy bypass via IP alias allows SSRF",
+          "url": "https://github.com/advisories/GHSA-m7pr-hjqh-92cm",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-918"
+          ],
+          "cvss": {
+            "score": 6.8,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N"
+          },
+          "range": ">=1.0.0 <1.15.1"
+        },
+        {
+          "source": 1117587,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "Axios' HTTP adapter-streamed uploads bypass maxBodyLength when maxRedirects: 0",
+          "url": "https://github.com/advisories/GHSA-5c9x-8gcm-mpgx",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-770"
+          ],
+          "cvss": {
+            "score": 5.3,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+          },
+          "range": ">=1.0.0 <1.15.1"
+        },
+        {
+          "source": 1117589,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "Axios: HTTP adapter streamed responses bypass maxContentLength",
+          "url": "https://github.com/advisories/GHSA-vf2m-468p-8v99",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-770"
+          ],
+          "cvss": {
+            "score": 5.3,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+          },
+          "range": ">=1.0.0 <1.15.1"
+        },
+        {
+          "source": 1117591,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "Axios: Prototype Pollution Gadgets - Response Tampering, Data Exfiltration, and Request Hijacking",
+          "url": "https://github.com/advisories/GHSA-pf86-5x62-jrwf",
+          "severity": "high",
+          "cwe": [
+            "CWE-1321"
+          ],
+          "cvss": {
+            "score": 7.4,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N"
+          },
+          "range": ">=1.0.0 <1.15.1"
+        },
+        {
+          "source": 1117593,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "Axios: Header Injection via Prototype Pollution",
+          "url": "https://github.com/advisories/GHSA-6chq-wfr3-2hj9",
+          "severity": "high",
+          "cwe": [
+            "CWE-113",
+            "CWE-1321"
+          ],
+          "cvss": {
+            "score": 7.4,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N"
+          },
+          "range": ">=1.0.0 <1.15.1"
+        },
+        {
+          "source": 1117595,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "Axios: XSRF Token Cross-Origin Leakage via Prototype Pollution Gadget in `withXSRFToken` Boolean Coercion",
+          "url": "https://github.com/advisories/GHSA-xx6v-rp6x-q39c",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-183",
+            "CWE-201"
+          ],
+          "cvss": {
+            "score": 5.4,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+          },
+          "range": ">=1.0.0 <1.15.1"
+        },
+        {
+          "source": 1118607,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "Axios has prototype pollution read-side gadgets in HTTP adapter that allow credential injection and request hijacking",
+          "url": "https://github.com/advisories/GHSA-q8qp-cvcw-x6jj",
+          "severity": "high",
+          "cwe": [
+            "CWE-1321"
+          ],
+          "cvss": {
+            "score": 7.4,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N"
+          },
+          "range": ">=1.0.0 <1.15.2"
+        },
+        {
+          "source": 1119667,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "axios's shouldBypassProxy does not recognize IPv4-mapped IPv6 addresses, allowing NO_PROXY bypass (incomplete fix for CVE-2025-62718)",
+          "url": "https://github.com/advisories/GHSA-pjwm-pj3p-43mv",
+          "severity": "high",
+          "cwe": [
+            "CWE-918"
+          ],
+          "cvss": {
+            "score": 8.6,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
+          },
+          "range": ">=1.0.0 <1.16.0"
+        },
+        {
+          "source": 1119669,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "axios has DoS & Header Injection via Prototype Pollution Read-Side Gadgets in axios merge functions",
+          "url": "https://github.com/advisories/GHSA-898c-q2cr-xwhg",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-1321"
+          ],
+          "cvss": {
+            "score": 4.8,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:L"
+          },
+          "range": ">=1.0.0 <1.16.0"
+        },
+        {
+          "source": 1119674,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "axios Vulnerable to Credential Theft and Response Hijacking via Prototype Pollution Gadget in Config Merge",
+          "url": "https://github.com/advisories/GHSA-3g43-6gmg-66jw",
+          "severity": "high",
+          "cwe": [
+            "CWE-94",
+            "CWE-1321"
+          ],
+          "cvss": {
+            "score": 7,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:L"
+          },
+          "range": ">=1.0.0 <1.15.2"
+        },
+        {
+          "source": 1119675,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "axios Vulnerable to Full Man-in-the-Middle via Prototype Pollution Gadget in `config.proxy`",
+          "url": "https://github.com/advisories/GHSA-35jp-ww65-95wh",
+          "severity": "high",
+          "cwe": [
+            "CWE-441",
+            "CWE-1321"
+          ],
+          "cvss": {
+            "score": 8.7,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:N"
+          },
+          "range": ">=1.0.0 <1.16.0"
+        },
+        {
+          "source": 1120073,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "Axios: Regular Expression Denial of Service (ReDoS) via Cookie Name Injection",
+          "url": "https://github.com/advisories/GHSA-hfxv-24rg-xrqf",
+          "severity": "high",
+          "cwe": [
+            "CWE-400",
+            "CWE-1333"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          "range": ">=1.0.0 <1.16.0"
+        },
+        {
+          "source": 1120074,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "Allocation of Resources Without Limits or Throttling in Axios",
+          "url": "https://github.com/advisories/GHSA-777c-7fjr-54vf",
+          "severity": "high",
+          "cwe": [
+            "CWE-770"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          "range": ">=1.7.0 <1.16.0"
+        },
+        {
+          "source": 1120076,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "Axios: Proxy-Authorization Credential Leak to Origin Server Across HTTP-to-HTTPS Redirect in Axios Node.js HTTP Adapter",
+          "url": "https://github.com/advisories/GHSA-p92q-9vqr-4j8v",
+          "severity": "high",
+          "cwe": [
+            "CWE-201"
+          ],
+          "cvss": {
+            "score": 0,
+            "vectorString": null
+          },
+          "range": ">=1.0.0 <1.16.0"
+        },
+        {
+          "source": 1120078,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "Axios: Proxy-Authorization header leaks to redirect target when proxy is re-evaluated to direct connection",
+          "url": "https://github.com/advisories/GHSA-j5f8-grm9-p9fc",
+          "severity": "high",
+          "cwe": [
+            "CWE-200"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+          },
+          "range": ">=1.0.0 <1.16.0"
+        },
+        {
+          "source": 1120125,
+          "name": "axios",
+          "dependency": "axios",
+          "title": "Axios: unbounded recursion in toFormData causes DoS via deeply nested request data",
+          "url": "https://github.com/advisories/GHSA-62hf-57xw-28j9",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-674"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          "range": ">=1.0.0 <1.15.1"
+        }
+      ],
+      "effects": [],
+      "range": "1.0.0 - 1.15.2",
+      "nodes": [
+        "node_modules/axios"
+      ],
+      "fixAvailable": true
+    },
+    "esbuild": {
+      "name": "esbuild",
+      "severity": "moderate",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1102341,
+          "name": "esbuild",
+          "dependency": "esbuild",
+          "title": "esbuild enables any website to send any requests to the development server and read the response",
+          "url": "https://github.com/advisories/GHSA-67mh-4wv8-2f99",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-346"
+          ],
+          "cvss": {
+            "score": 5.3,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:N/A:N"
+          },
+          "range": "<=0.24.2"
+        }
+      ],
+      "effects": [
+        "vite"
+      ],
+      "range": "<=0.24.2",
+      "nodes": [
+        "node_modules/esbuild"
+      ],
+      "fixAvailable": {
+        "name": "vite",
+        "version": "8.0.16",
+        "isSemVerMajor": true
+      }
+    },
+    "uuid": {
+      "name": "uuid",
+      "severity": "moderate",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1119442,
+          "name": "uuid",
+          "dependency": "uuid",
+          "title": "uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided",
+          "url": "https://github.com/advisories/GHSA-w5hq-g745-h8pq",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-787",
+            "CWE-1285"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+          },
+          "range": ">=13.0.0 <13.0.1"
+        }
+      ],
+      "effects": [],
+      "range": "13.0.0",
+      "nodes": [
+        "node_modules/uuid"
+      ],
+      "fixAvailable": true
+    },
+    "vite": {
+      "name": "vite",
+      "severity": "moderate",
+      "isDirect": true,
+      "via": [
+        {
+          "source": 1116229,
+          "name": "vite",
+          "dependency": "vite",
+          "title": "Vite Vulnerable to Path Traversal in Optimized Deps `.map` Handling",
+          "url": "https://github.com/advisories/GHSA-4w7w-66w2-5vf9",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-22",
+            "CWE-200"
+          ],
+          "cvss": {
+            "score": 0,
+            "vectorString": null
+          },
+          "range": "<=6.4.1"
+        },
+        "esbuild"
+      ],
+      "effects": [
+        "@vitejs/plugin-vue"
+      ],
+      "range": "<=6.4.1",
+      "nodes": [
+        "node_modules/vite"
+      ],
+      "fixAvailable": {
+        "name": "vite",
+        "version": "8.0.16",
+        "isSemVerMajor": true
+      }
+    }
+  },
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 4,
+      "high": 1,
+      "critical": 0,
+      "total": 5
+    },
+    "dependencies": {
+      "prod": 61,
+      "dev": 163,
+      "optional": 50,
+      "peer": 6,
+      "peerOptional": 0,
+      "total": 230
+    }
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "depl0y-frontend",
-  "version": "2.2.49",
+  "version": "2.2.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "depl0y-frontend",
-      "version": "2.2.49",
+      "version": "2.2.74",
       "dependencies": {
         "axios": "^1.6.2",
         "chart.js": "^4.4.0",
@@ -1151,6 +1151,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -1208,13 +1220,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -1385,7 +1398,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2046,6 +2058,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2311,7 +2336,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2826,9 +2850,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/npm-supply-chain-audit-report.md
+++ b/npm-supply-chain-audit-report.md
@@ -1,0 +1,102 @@
+# npm supply-chain audit — agit8or1 public repos
+
+**Date:** 2026-06-08
+**Auditor:** Claude Code (Opus 4.7) on behalf of agit8or1
+**Trigger:** Active npm supply-chain incident (Shai-Hulud / Mini Shai-Hulud style; reports of compromised packages across `@tanstack/*`, `@mistralai/*`, `@antv/*`, `@redhat-cloud-services/*` namespaces; postinstall-payload credential stealers; `axios` 1.14.1 / 0.30.4 backdoored)
+**Tooling:** node 22.21.1, npm 10.9.4, pnpm 11.5.2 (via corepack)
+**Constraints applied:** no `npm install` / `pnpm install` without `--ignore-scripts`; lockfile-only mode wherever possible; no build/test execution; no production touching; no `--force`.
+
+## Repos inspected
+
+| Repo | npm ecosystem? | Package manager | Action | Notes |
+|---|---|---|---|---|
+| **Depl0y** | yes | npm | audited + fixed | single `frontend/` project, Vite SPA |
+| **St0r** | yes | npm | audited + fixed; generated missing lockfile in `agent/` | 3 sub-projects (agent / backend / frontend) — `agent/` had no lockfile, now has one |
+| **rem0te** | yes | pnpm | audited + fixed | pnpm-workspace monorepo: root + types + launcher + api + web |
+| **clientst0r** | no | — | skipped | Python project, no JS files |
+| **OPNMGR** | no | — | skipped | PHP project, no JS files |
+
+## Static risk scan — known indicators
+
+Searched every `package.json` and every lockfile for:
+`@tanstack/*`, `@antv/*`, `@redhat-cloud-services/*`, `@mistralai/*`, `@bitwarden/cli`, `plain-crypto-js`, `axios@1.14.1`, `axios@0.30.4`, packages with declared lifecycle scripts, non-default registry resolutions, git/tarball URL resolutions.
+
+**Findings:**
+- No `@antv/*`, `@redhat-cloud-services/*`, `@mistralai/*`, `@bitwarden/cli`, `plain-crypto-js` declared in any package.
+- **One `@tanstack/*` hit:** `@tanstack/react-query@^5.59.20` in `rem0te/apps/web` — resolved to `5.90.21`. This is a current stable release, **not** in any known compromised version window. No remediation needed for this package itself; flagged for awareness only.
+- **No `axios@1.14.1` or `axios@0.30.4`** anywhere. Versions found:
+  - Depl0y/frontend: `1.15.0` (declared `^1.6.2`) → audit-fixed to a newer 1.15.x
+  - St0r/backend: `1.16.1` (declared `^1.13.1`)
+  - St0r/frontend: `1.16.1` (declared `^1.6.2`)
+  - rem0te/apps/web: was `1.13.6`, now `1.17.0` (declared bumped from `^1.7.7` to `^1.17.0`) — `1.13.6` was affected by ~12 patched CVEs (SSRF / prototype-pollution / header injection / etc.), all resolved in 1.15.2+.
+- **No top-level `preinstall/install/postinstall/prepack/prepare/prepublish*` scripts** in any of the 9 inspected `package.json` files.
+- **Lockfile-level install scripts** were limited to well-known native-compile packages: `esbuild`, `fsevents`, `vue-demi`, `bcrypt`, `cpu-features`, `sqlite3`, `ssh2`. No anomalous install-script packages.
+- **All lockfile resolutions point to `registry.npmjs.org`** with sha512 integrity hashes. No `git+`, `github:`, `file:`, or alternate-tarball resolutions in any lockfile.
+- **No `.npmrc` / `.yarnrc` / `.yarnrc.yml`** files anywhere — no token leakage risk in committed files.
+
+**Conclusion on supply-chain indicators:** no obvious indicators of the current Shai-Hulud campaign in any of the three affected repos. The audit still proceeded with full lockfile refresh + advisory fixes as defense-in-depth.
+
+## Audit results (advisory counts)
+
+### Depl0y — `frontend/`
+| | Before | After |
+|---|---|---|
+| critical | 0 | 0 |
+| high | 1 (axios) | 0 |
+| moderate | 4 (vite, esbuild, @vitejs/plugin-vue, uuid) | 3 (vite/esbuild/@vitejs/plugin-vue) |
+| **total** | **5** | **3** |
+
+**Remaining (3 moderate):** all dev-tool only — `vite@5.x`, `esbuild@0.21.x`, `@vitejs/plugin-vue@5.x`. CVEs only affect the local dev server's behaviour (`npm run dev`), not production builds. Patching requires Vite **5 → 8** major bump (`@vitejs/plugin-vue 4 → 6`); deferred to a separate migration ticket — not a runtime risk.
+
+### St0r — `agent/`, `backend/`, `frontend/`
+| Project | Before | After | Notes |
+|---|---|---|---|
+| `agent/` | (no lockfile) → 0 | 0 | Lockfile was missing — generated with `npm install --package-lock-only --ignore-scripts`. |
+| `backend/` | 3 moderate (qs / body-parser / express) | 0 | |
+| `frontend/` | 2 moderate (react-router / react-router-dom) | 0 | |
+
+### rem0te — pnpm workspace
+| | Before | After |
+|---|---|---|
+| critical | 1 (Next.js middleware auth bypass) | 0 |
+| high | 26 | 6 |
+| moderate | 40 | 11 |
+| low | 5 | 2 |
+| **total advisories** | **72** | **19** |
+
+**Critical** (CVE Next.js middleware authorization bypass) is resolved by bumping `next` from pinned `14.2.18` → `14.2.35` (latest secure 14.2.x release).
+
+**Remaining 19 advisories** all fall into one of two buckets:
+1. **Requires Next.js 15.x major upgrade** (14 of 19 next-related findings). Patched only in 15.x; Next 14 → 15 is a major migration (React 19 alignment, new caching semantics) — **explicitly deferred** to a separate task per the audit rule "Avoid broad pnpm update --latest unless required and explain why".
+2. **Deep transitive deps** (`fast-uri`, `flatted`, `glob`, `lodash`, `path-to-regexp`, `picomatch`, `brace-expansion`, `ajv`, `qs`, `file-type`, `esbuild`, `vite`) pulled in via `@nestjs/cli`, `eslint`, `eslint-config-next`, `tailwindcss`. Direct fix would require either: (a) major bumps in those direct dev/build deps, or (b) `pnpm.overrides` injection. Both have non-trivial blast radius and were deferred.
+
+## What got changed
+
+| Repo | Files modified | New files |
+|---|---|---|
+| Depl0y | `frontend/package-lock.json` | `frontend/SECURITY-NPM-AUDIT.md`, `frontend/npm-audit.before.json`, `frontend/npm-audit.after.json` |
+| St0r | `backend/package-lock.json`, `frontend/package-lock.json` | `agent/package-lock.json` (new), `agent/SECURITY-NPM-AUDIT.md`, `backend/SECURITY-NPM-AUDIT.md`, `frontend/SECURITY-NPM-AUDIT.md`, `agent/npm-audit.{before,after}.json`, `backend/npm-audit.{before,after}.json`, `frontend/npm-audit.{before,after}.json` |
+| rem0te | `pnpm-lock.yaml`, `apps/api/package.json`, `apps/web/package.json`, `apps/launcher/package.json`, `package.json` | `SECURITY-NPM-AUDIT.md`, `pnpm-audit.before.json`, `pnpm-audit.after.json` |
+
+**Production files NOT touched** — server installs at `/opt/depl0y/`, etc. remain on prior bundles.
+
+## What needs manual review
+
+- **Depl0y/frontend:** plan Vite 5 → 8 + `@vitejs/plugin-vue` 4 → 6 migration. Low urgency (dev-server-only CVEs) but worth a separate PR to clear the audit cleanly.
+- **rem0te/apps/web:** plan Next.js 14 → 15 migration. Higher urgency — clears 14 remaining advisories including high-severity SSRF/DoS variants. Requires React 19 alignment, caching-API review.
+- **rem0te (general):** evaluate `pnpm.overrides` for the deep transitives (`lodash@^4.17.24`, `glob@^10.5.0`, `picomatch@^4.0.4`, `path-to-regexp@^8.4.0`, `brace-expansion@^2.0.2`, `fast-uri@^3.1.2`, `flatted@^3.4.2`). Adds maintenance burden, but cheap individually.
+- **St0r/agent:** new lockfile is now in place — schedule a clean-install CI run with `--ignore-scripts` first to verify no postinstall has been silently relied upon.
+
+## Credentials/tokens — rotation guidance
+
+No tokens were found in any committed file (`.npmrc`, `.yarnrc`, `.yarnrc.yml` are absent from all repos). No `_authToken` or `npmRegistryServer` overrides in any repo. **No credential rotation indicated by this audit.** Independently of this audit:
+- A prior GitHub PAT (`ghp_faUGfW…`) was embedded in the depl0y origin URL until 2026-06-08; that one was rotated; the replacement is now stored in a 0600 git credential file. If you ever pushed those repos to a CI runner that logged the remote URL, treat the old PAT as compromised and confirm it's been revoked at github.com/settings/tokens.
+
+## Branches pushed
+
+- `chore/npm-supply-chain-audit-2026-06` on:
+  - github.com/agit8or1/Depl0y
+  - github.com/agit8or1/St0r
+  - github.com/agit8or1/rem0te
+
+`clientst0r` and `OPNMGR` had no npm ecosystem and were not touched.


### PR DESCRIPTION
## Summary

- Audited npm/pnpm dependencies for supply-chain compromise indicators
- Applied safe lockfile-only dependency updates
- Added audit before/after reports
- Pushed branch `chore/npm-supply-chain-audit-2026-06`

## Results

No obvious Shai-Hulud-style compromise indicators were found.

## Notes

- No install scripts were executed
- No node_modules install was performed
- No production paths were touched
- No token/env files were staged

## Follow-up

See `npm-supply-chain-audit-report.md` and related SECURITY-NPM-AUDIT files for remaining advisories and manual migration notes.
